### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/cubicle-jockey/cj_bitmask_vec/security/code-scanning/1](https://github.com/cubicle-jockey/cj_bitmask_vec/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs basic CI tasks (building and testing), it requires minimal permissions. The `contents: read` permission is sufficient for these operations. This change will ensure that the workflow does not inherit overly permissive defaults and adheres to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
