### PR TITLE
Fix iteration API

### DIFF
--- a/src/cj_bitmask_vec.rs
+++ b/src/cj_bitmask_vec.rs
@@ -386,7 +386,7 @@ where
     /// assert_eq!(total, 721);
     /// ```
     #[inline]
-    pub fn iter(&'a mut self) -> BitmaskVecIter<'a, B, T> {
+    pub fn iter(&'a self) -> BitmaskVecIter<'a, B, T> {
         BitmaskVecIter::new(self.inner.iter())
     }
 
@@ -412,7 +412,7 @@ where
     /// assert_eq!(total, 306);
     /// ```
     #[inline]
-    pub fn iter_with_mask(&'a mut self) -> BitmaskVecIterWithMask<'a, B, T> {
+    pub fn iter_with_mask(&'a self) -> BitmaskVecIterWithMask<'a, B, T> {
         BitmaskVecIterWithMask::new(self.inner.iter())
     }
 


### PR DESCRIPTION
## Summary
- allow immutable access for `iter` and `iter_with_mask`

## Testing
- `cargo test --color=never`

------
https://chatgpt.com/codex/tasks/task_b_688d4d8129708329bc2974b70c7f350c