### PR TITLE
Add test for filter_mask none condition

### DIFF
--- a/src/cj_bitmask_vec.rs
+++ b/src/cj_bitmask_vec.rs
@@ -998,6 +998,16 @@ mod test {
     }
 
     #[test]
+    fn test_bitmask_vec_with_mask_filter_none() {
+        let mut v = BitmaskVec::<u8, i32>::new();
+        v.push_with_mask(0b00000000, 100);
+        v.push_with_mask(0b00000010, 101);
+
+        let mut z = v.iter_with_mask();
+        assert!(z.filter_mask(&0b00000100).is_none());
+    }
+
+    #[test]
     fn test_bitmask_vec_iter_mut() {
         let mut v = BitmaskVec::<u8, i32>::new();
         v.push_with_mask(0b00000000, 100);


### PR DESCRIPTION
## Summary
- add unit test ensuring filter_mask returns None when mask has no matches

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_688d6e78d16083298a557adc7053bc40